### PR TITLE
Split

### DIFF
--- a/scaleup.plugin.js
+++ b/scaleup.plugin.js
@@ -335,7 +335,7 @@ function onScaleUpClick(origRequest, image) {
     //delete newTaskRequest.reqBody.hypernetwork_strength;
     //delete newTaskRequest.reqBody.use_hypernetwork_model;
   }
-  //Grab the model name from the user-input area instead of the original image.
+  
   newTaskRequest.reqBody.use_stable_diffusion_model=desiredModel;
   
   //Grab the prompt from the user-input area instead of the original image.
@@ -413,9 +413,12 @@ function ScaleUpMax(dimension, ratio) {
 }
   
 function onScaleUpMAXClick(origRequest, image) {
+  //Grab the model name from the user-input area instead of the original image.
+  var desiredModel=$("#editor-settings #stable_diffusion_model").val(); //origRequest.use_stable_diffusion_model for the original model
+
   var isXl=false;
   var maxRes=maxTotalResolution;
-  if (isModelXl(origRequest.use_stable_diffusion_model)) {
+  if (isModelXl(desiredModel)) {
     maxRes=maxTotalResolutionXL;
     isXl=true;
   }
@@ -458,6 +461,9 @@ function onScaleUpMAXClick(origRequest, image) {
     //newTaskRequest.reqBody.turbo = false;
     newTaskRequest.reqBody.vram_usage_level = 'low';
   }
+
+  newTaskRequest.reqBody.use_stable_diffusion_model=desiredModel;
+
   delete newTaskRequest.reqBody.mask
   createTask(newTaskRequest)
 }
@@ -466,7 +472,7 @@ var scaleUpMaxRatio;
 function scaleUpMAXFilter(origRequest) {
   let result = false;
   var maxRes=maxTotalResolution;
-  if (isModelXl(origRequest.use_stable_diffusion_model)) {
+  if (isModelXl($("#editor-settings #stable_diffusion_model").val())) {  //origRequest.use_stable_diffusion_model
     maxRes=maxTotalResolutionXL;
   }
 

--- a/scaleup.plugin.js
+++ b/scaleup.plugin.js
@@ -29,14 +29,23 @@
 EDIT THIS to put in the maximum resolutions your video card can handle. 
 These values work (usually) for the Nvidia 2060 Super with 8GB VRAM. 
 If you go too large, you'll see "Error: CUDA out of memory". 
+
+The ideal maximum amount may vary depending upon not just the amount of
+installed VRAM, but if using Nvidia driver v532 or greater, half of your
+system RAM is also available for use (if slower).  Edit these values
+to find the right balance; you may want a higher size if your memory
+allows, or you may want to keep values lower, for faster run-times.
+Installing xformers will also greatly reduce the RAM impact, and allow
+for much greater sizes.
 ***********************************************************************/
 (function() { "use strict"
-//SDXL limits:2048*2048 or better
 //Original 1.5 limits: 1280 * 1536 ( 1536	* 896 balanced?)
+//For 8GB VRAM and xformers, try 2592 * 2016 or more.
 var maxTotalResolution = 2048	* 1088; //put max 'low' mode resolution here, max possible size when low mode is on
 var maxTurboResolution = 1088	* 1664; //put max 'balanced' resolution here - larger output will enter 'low' mode, automatically.
 var MaxSquareResolution = 1344;
 
+//SDXL limits:2048*2048 or better
 var maxTotalResolutionXL = 3072	* 2304;  //maximum resolution to use in 'low' mode for SDXL.  Even for 8GB video cards, this number maybe able to be raised.
 
 
@@ -153,7 +162,7 @@ function isModelXl(modelName) {
 }
 
 
-const suLabel = 'Scale Up BETA';  //base label prefix
+const suLabel = 'Scale Up';  //base label prefix
 PLUGINS['IMAGE_INFO_BUTTONS'].push([
   { html: '<span class="scaleup-label" style="background-color:transparent;background: rgba(0,0,0,0.5)">'+
     '<span class="scaleup-tooltiptext">Click to cycle through modes - "preserve", for fewer changes to the image, '+
@@ -319,7 +328,7 @@ function onScaleUpClick(origRequest, image) {
   if (scaleUpControlNet && !isXl)
   {
     newTaskRequest.reqBody.control_image = image.src;
-    newTaskRequest.reqBody.use_controlnet_model = "control_v11f1e_sd15_tile";
+    newTaskRequest.reqBody.use_controlnet_model = isXl? "diffusers_xl_canny_full":"control_v11f1e_sd15_tile";
     newTaskRequest.reqBody.prompt_strength = scaleUpPreserve ? 0.3 : 0.5;
   }
 
@@ -447,7 +456,7 @@ function onScaleUpMAXClick(origRequest, image) {
   if (scaleUpControlNet && !isXl)
   {
     newTaskRequest.reqBody.control_image = image.src;
-    newTaskRequest.reqBody.use_controlnet_model = "control_v11f1e_sd15_tile";
+    newTaskRequest.reqBody.use_controlnet_model = isXl? "diffusers_xl_canny_full":"control_v11f1e_sd15_tile";
     newTaskRequest.reqBody.prompt_strength = scaleUpPreserve ? 0.3 : 0.5;
   }
 

--- a/scaleup.plugin.js
+++ b/scaleup.plugin.js
@@ -1,6 +1,6 @@
 /**
  * Scale Up
- * v.1.3.2, last updated: 8/1/2023
+ * v.1.3.3, last updated: 8/25/2023
  * By Gary W.
  * 
  * Modest scaling up, maintaining close ratio, with img2img to increase resolution of output.
@@ -143,13 +143,120 @@ function scaleUp(height,width) {
   }
   return result;
 }
-
+const suLabel = 'Scale Up BETA';  //base label prefix
 PLUGINS['IMAGE_INFO_BUTTONS'].push([
-  { html: '<span class="scaleup-label" style="background-color:transparent;background: rgba(0,0,0,0.5)">Scale Up BETA:</span>', type: 'label', on_click: onScaleUpLabelClick, filter: onScaleUpLabelFilter},
+  { html: '<span class="scaleup-label" style="background-color:transparent;background: rgba(0,0,0,0.5)">'+
+    '<span class="scaleup-tooltiptext">Click to toggle "preserve" mode, for fewer changes to the image. \n'+
+    'Clicking on a resolution will generate a new image at that resolution. \n'+
+    'Click on the grid icon to generate 4 tiled images, for more resolution once stitched.</span>'
+    +suLabel+':</span>', type: 'label', 
+    on_click: onScaleUpLabelClick, filter: onScaleUpLabelFilter},
   { text: 'Scale Up', on_click: onScaleUpClick, filter: onScaleUpFilter },
   { text: 'Scale Up MAX', on_click: onScaleUpMAXClick, filter: onScaleUpMAXFilter },
   { html: '<i class="fa-solid fa-th-large"></i>', on_click: onScaleUpSplitClick, filter: onScaleUpSplitFilter  }
 ])
+/* Note: Tooltip will be removed once the label is clicked. */
+
+const style = document.createElement('style');
+style.textContent = `
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.scaleup-label:hover .scaleup-tooltiptext {
+  visibility: visible;
+}
+
+/* See: https://stackoverflow.com/questions/13811538/how-to-delay-basic-html-tooltip */
+
+
+.scaleup-label .scaleup-tooltiptext {
+  visibility: hidden;
+  width: 400px;
+  background-color: #444;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+  top: 100%;
+  right: 50%;
+  opacity: 1;
+  transition: opacity 1s;
+}
+
+.scaleup-label .tooltiptext::after {
+  content: " ";
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  /* To the left of the tooltip */
+  margin-top: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent #545 transparent transparent;
+}
+
+
+/*hover with animation*/
+
+.scaleup-label:hover .scaleup-tooltiptext {
+  visibility: visible;
+  animation: tooltipkeys 1s 1; //delay time
+  opacity: 1;
+}
+
+@-webkit-keyframes tooltipkeys {
+  0% {
+    opacity: 0;
+  }
+  75% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@-moz-keyframes tooltipkeys {
+  0% {
+    opacity: 0;
+  }
+  75% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@-o-keyframes tooltipkeys {
+  0% {
+    opacity: 0;
+  }
+  75% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes tooltipkeys {
+  0% {
+    opacity: 0;
+  }
+  75% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+`;
+document.head.append(style);
+
 //font-size:20px 
 var scaleUpPreserve = false;
 function onScaleUpLabelClick(origRequest, image) {
@@ -250,10 +357,10 @@ function scaleupLabel(atMaxRes)
 {
   var text;
   if (!scaleUpPreserve) {
-    text = 'Scale Up BETA';
+    text = suLabel;
   }
   else {
-    text = 'Scale Up BETA (preserve)';
+    text = suLabel+' (preserve)';
   }
   //At max resolution, we can no longer do the normal scaleup, but we can still split -- offer a reminder
   if (atMaxRes) {

--- a/scaleup.plugin.js
+++ b/scaleup.plugin.js
@@ -1,12 +1,13 @@
 /**
  * Scale Up
- * v.1.3.4, last updated: 8/27/2023
+ * v.1.3.5, last updated: 9/3/2023
  * By Gary W.
  * 
  * Modest scaling up, maintaining close ratio, with img2img to increase resolution of output.
  * 
  * Updated to support newer "diffusors" version of Easy Diffusion and SDXL, which can make use
- * of much higher resolutions than before.
+ * of much higher resolutions than before.  (Note that new Nvidia drivers [since version 532]
+ * and installing xformers will allow even further higher resolution limits.)
  *  
  * The expected workflow is to use ScaleUp to gradually increase resolution, while allowing 
  * Stable Diffusion to add detail.  At some point, when you're satisfied with the results,
@@ -19,14 +20,18 @@
  * Another big change is that ScaleUp will grab the prompt AND the model name from the input
  * area, not from the source image. This allows you to easily swap from "base" to "refiner".
  * 
- * Now uses the original sampler from the original image, not "ddim".
+ * Now uses the original sampler from the original image, not "ddim".  Uses the model specified
+ * in the UI, not in the original image, so that you may change models as you scale-up.
+ * Added support for controlnet, to allow more detail without as much severe modifications
+ * to the original image.
+ * 
  * 
  * Free to use with the CMDR2 Stable Diffusion UI.
- *  
+ * 
  */
 
 /**********************************************************************
-EDIT THIS to put in the maximum resolutions your video card can handle. 
+EDIT THE BELOW to put in the maximum resolutions your video card can handle. 
 These values work (usually) for the Nvidia 2060 Super with 8GB VRAM. 
 If you go too large, you'll see "Error: CUDA out of memory". 
 
@@ -39,6 +44,7 @@ Installing xformers will also greatly reduce the RAM impact, and allow
 for much greater sizes.
 ***********************************************************************/
 (function() { "use strict"
+
 //Original 1.5 limits: 1280 * 1536 ( 1536	* 896 balanced?)
 //For 8GB VRAM and xformers, try 2592 * 2016 or more.
 var maxTotalResolution = 2048	* 1088; //put max 'low' mode resolution here, max possible size when low mode is on

--- a/scaleup.plugin.js
+++ b/scaleup.plugin.js
@@ -198,7 +198,7 @@ function onScaleUpClick(origRequest, image) {
   newTaskRequest.reqBody.use_stable_diffusion_model=$("#editor-settings #stable_diffusion_model").val();
   
   //Grab the prompt from the user-input area instead of the original image.
-  newTaskRequest.reqBody.prompt=$("textarea#prompt").val();
+  //newTaskRequest.reqBody.prompt=$("textarea#prompt").val();
   
   delete newTaskRequest.reqBody.mask
   createTask(newTaskRequest)

--- a/scaleup.plugin.js
+++ b/scaleup.plugin.js
@@ -305,7 +305,7 @@ function onScaleUpClick(origRequest, image) {
   {
     newTaskRequest.reqBody.control_image = image.src;
     newTaskRequest.reqBody.use_controlnet_model = "control_v11f1e_sd15_tile";
-    newTaskRequest.reqBody.prompt_strength = scaleUpPreserve ? 0.4 : 0.7;
+    newTaskRequest.reqBody.prompt_strength = scaleUpPreserve ? 0.3 : 0.5;
   }
 
   newTaskRequest.seed = newTaskRequest.reqBody.seed
@@ -427,7 +427,7 @@ function onScaleUpMAXClick(origRequest, image) {
   {
     newTaskRequest.reqBody.control_image = image.src;
     newTaskRequest.reqBody.use_controlnet_model = "control_v11f1e_sd15_tile";
-    newTaskRequest.reqBody.prompt_strength = scaleUpPreserve ? 0.4 : 0.7;
+    newTaskRequest.reqBody.prompt_strength = scaleUpPreserve ? 0.3 : 0.5;
   }
 
   newTaskRequest.seed = newTaskRequest.reqBody.seed


### PR DESCRIPTION
 * Now uses the original sampler from the original image, not "ddim".  
 * Uses the model specified in the UI, not in the original image, so that you may change models as you scale-up.
 * Added support for controlnet, to allow more detail without as much severe modifications to the original image.